### PR TITLE
Fixing the devcontainer image name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "ollama-js",
 
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworn",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
Fixing the devcontainer image to "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm" - otherwise not able to use Codepsaces.